### PR TITLE
Add the ability to skip remote publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ You can also specify your private key with `--privkey` argument. Note that your 
 $ yarn deploy --zeronet=/path/to/zeronet --privkey=sEcReTkEy
 ```
 
+If you would like to prevent publishing your site publicly, you can use the `--no-publish` option. Site files will still be built and signed.
+
+```bash
+$ yarn deploy --zeronet=/path/to/zeronet --privkey=sEcReTkEy --no-publish
+```
+
 #### Continuous deployment
 
 You can also use continuous deployment with Travis CI.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,6 +84,7 @@ gulp.task('deploy', gulp.series('build', function (done) {
   let silent = argv.silent
   let zeronet = argv.zeronet
   let privkey = argv.privkey ? argv.privkey : ''
+  let doPublish = argv.publish
 
   if (!zeronet) {
     throw new PluginError({
@@ -146,6 +147,11 @@ gulp.task('deploy', gulp.series('build', function (done) {
 
     sign.on('exit', function (code, signal) {
       log('Signing done')
+
+      if (!doPublish) {
+        done()
+        return
+      }
 
       log('Publishing site')
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,6 +149,7 @@ gulp.task('deploy', gulp.series('build', function (done) {
       log('Signing done')
 
       if (!doPublish) {
+        log('Skipping publishing')
         done()
         return
       }


### PR DESCRIPTION
I'd like to be able to quickly build/deploy my site files locally, without publishing changes to everyone immediately.

This PR adds the `--no-publish` option to skip the final publishing step.