### PR TITLE
Make publishing step default

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,10 @@ const prefix = require('gulp-autoprefixer')
 const clean = require('gulp-clean-css')
 const concat = require('gulp-concat')
 
-const argv = require('minimist')(process.argv.slice(2))
+const argv = require('minimist')(process.argv.slice(2), {
+  default: { publish: true }
+})
+
 const log = require('fancy-log')
 const PluginError = require('plugin-error')
 


### PR DESCRIPTION
A bit of a quick fix of #5. Publishing wasn't enabled unless you specified `--publish`.

This makes publishing default unless `--no-publish` is supplied.